### PR TITLE
fix(portail/messagerie): corriger recherche famille pour compte individu

### DIFF
--- a/noethysweb/portail/forms/messagerie.py
+++ b/noethysweb/portail/forms/messagerie.py
@@ -14,7 +14,7 @@ from core.utils.utils_commandes import Commandes
 from portail.forms.fiche import FormulaireBase
 from portail.utils.utils_summernote import SummernoteTextFormField
 
-from core.models import Famille
+from core.models import Famille, Rattachement
 
 
 class Formulaire(FormulaireBase, ModelForm):
@@ -44,7 +44,8 @@ class Formulaire(FormulaireBase, ModelForm):
         if hasattr(utilisateur, 'famille'):
             famille = utilisateur.famille
         elif hasattr(utilisateur, 'individu'):
-            famille = Famille.objects.filter(nom__icontains=utilisateur.individu).first()
+            rattachement = Rattachement.objects.filter(individu=utilisateur.individu, titulaire=1).first()
+            famille = rattachement.famille if rattachement else None
         else:
             famille = None  # Cas où l'utilisateur n'a ni famille ni individu
 


### PR DESCRIPTION
## Problème

quand une famille a deux titulaires (père + mère) avec des comptes individu, seul le premier titulaire pouvait envoyer des messages. le second recevait une erreur silencieuse (200 au lieu de 302).

## Cause

la famille était recherchée par nom (nom__icontains) 

fonctionne uniquemnt si le nom de l'individu apparaît dans le nom de la famille, ce qui échoue pour le second titulaire (ex: "---- Mathilde" absent de "---- Denis et ----").

## Fix

remplacement par une recherche via Rattachement (lien officiel entre individu et famille).

## Test

avant :
- Denis (premier titulaire) -> POST 302 
- Mathilde (second titulaire) -> POST 200  

après  : 
- Denis (premier titulaire) -> POST 302 
- Mathilde (second titulaire) -> POST 302  

