### PR TITLE
fix(portail/planning): corriger le crash AttributeError pour les individus rattachés à plusieurs familles

### DIFF
--- a/noethysweb/portail/views/planning.py
+++ b/noethysweb/portail/views/planning.py
@@ -41,8 +41,8 @@ class View(CustomView, TemplateView):
         if hasattr(self.request.user, 'famille'):
             return self.request.user.famille
         elif hasattr(self.request.user, 'individu'):
-            rattachement = Rattachement.objects.filter(individu=self.request.user.individu).first()
-            if rattachement.famille and rattachement.titulaire == 1:
+            rattachement = Rattachement.objects.filter(individu=self.request.user.individu, titulaire=1).first()
+            if rattachement and rattachement.famille:
                 return rattachement.famille
 
         return None


### PR DESCRIPTION
## Problème

Erreur 500 sur `/planning/<id>/<id>/<id>` pour les utilisateurs de type individu  rattachés à plusieurs familles.

`get_famille_object()` faisait un `.first()` sans filtre sur titulaire, retournant le premier rattachement en BDD qui pouvait ne pas être titulaire -> retournait `None` -> crash dans `utils_approbations.py` ligne 51 :

**AttributeError: 'NoneType' object has no attribute 'individus_masques'**

## Correction

- Filtre `titulaire=1` ajouté directement dans la requête SQL
- Guard `if rattachement` ajouté pour éviter le crash si aucun rattachement titulaire n'existe

## Test

Se connecter avec un compte individu rattaché à plusieurs familles et accéder au planning -> plus d'erreur 500.