### PR TITLE
fix(portail/planning): inclure grille_facturation.html pour corriger …

### DIFF
--- a/noethysweb/portail/templates/portail/planning.html
+++ b/noethysweb/portail/templates/portail/planning.html
@@ -86,15 +86,18 @@
 
     {# Grilles des réservations #}
     <div class="row">
-        <div class="col-md-12" >
-            <div class="card">
 
+        {% if parametres_portail.reservations_afficher_facturation %}
+            <div class="col-md-9">
+        {% else %}
+            <div class="col-md-12" >
+        {% endif %}
+
+            <div class="card">
                 {# Grille des consommations #}
                 <div class="card-body">
 
                     {# Texte d'introduction de la période #}
-                    {{ data.periode_reservation }}
-
                     {% if data.periode_reservation.introduction %}
                         <div class="d-print-none" style="margin-bottom: 10px;">
                             <i class="fa fa-info-circle margin-r-5"></i>{{ data.periode_reservation.introduction }}
@@ -125,13 +128,23 @@
                     </small></div>
 
                 </div>
-
             </div>
         </div>
+
+        {% if parametres_portail.reservations_afficher_facturation %}
+            <div class="col-md-3">
+                {% if parametres_portail.reservations_afficher_forfaits and data.tarifs_credits_exists %}
+                    {% include "consommations/grille_forfaits.html" %}
+                {% endif %}
+                {% include "consommations/grille_facturation.html" %}
+            </div>
+        {% endif %}
+
     </div>
 
     {% include 'consommations/grille_saisie_horaires.html' %}
     {% include 'consommations/grille_saisie_quantite.html' %}
     {% include 'consommations/grille_appliquer_semaine_type.html' %}
+    {% include 'consommations/grille_saisie_questionnaire.html' %}
 
 {% endblock contenu_page %}


### PR DESCRIPTION
## 📝 Pull Request Description

quand le paramètre **"Afficher la facturation"** est activé (Paramétrage > Portail > Paramètres généraux), le JS bloquait systématiquement l'enregistrement des réservations avec le message rouge *"Vous devez attendre la fin du calcul de la facturation avant de pouvoir quitter"*.

**Cause** : l'élément `#loader_facturation` (défini dans `grille_facturation.html`) n'était pas inclus dans le template portail `planning.html`, uniquement côté admin (`gestionnaire.html`). jQuery retourne `false` pour `hasClass()` sur un élément inexistant, ce qui bloquait toujours la soumission.

**Fix** : aligne le template sur `upstream/main` en incluant `grille_facturation.html` conditionnellement et en ajustant le layout en `col-md-9` / `col-md-3`.

---

### Target Branch
`deploy`

---

### Additional Notes
après vérification de l'historique, il semblerait que quelqu'un ait supprimé les blocs conditionnels liés à la facturation dans `planning.html` sur la branche `deploy`. 